### PR TITLE
GitHub Actionsの環境変数CIを削除

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@v1.6
-        if: always()
+        if: failure()
         with:
           job_name: '*Node CI*'
           type: ${{ job.status }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,18 +33,12 @@ jobs:
 
       - name: Run yarn install
         run: yarn install
-        env:
-          CI: true
 
       - name: Run yarn build
         run: yarn run build
-        env:
-          CI: true
 
       - name: Run yarn lint
         run: yarn run lint
-        env:
-          CI: true
 
       - name: Slack Notification
         uses: homoluctus/slatify@v1.6


### PR DESCRIPTION
# 概要

GitHub Actionsの環境変数CIを削除．
デフォルトでCIがtrueになるので不要．