### PR TITLE
GitHub Actionsの通知を失敗時だけにする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@v1.6
-        if: always()
+        if: failure()
         with:
           job_name: '*Node CI*'
           type: ${{ job.status }}


### PR DESCRIPTION
# 概要

GitHub Actionsの通知を失敗時だけにする．
成功時の通知は大体不要なので切る．