### PR TITLE
Composition APIに移行

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.18.1]
+        node-version: [14.17.4]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.4-slim
+FROM node:14.17.4-slim
 
 WORKDIR /app
 

--- a/components/MarkDownContent.vue
+++ b/components/MarkDownContent.vue
@@ -4,10 +4,10 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { computed, defineComponent, PropOptions } from '@nuxtjs/composition-api';
 import marked, { MarkedOptions } from 'marked';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'MarkDownContent',
   props: {
     source: {
@@ -22,10 +22,12 @@ export default Vue.extend({
       },
     } as PropOptions<MarkedOptions>,
   },
-  computed: {
-    markedContent (): string {
-      return marked(this.source, this.options);
-    },
+  setup (props) {
+    const markedContent = computed<string>(() => marked(props.source, props.options));
+
+    return {
+      markedContent,
+    };
   },
 });
 </script>

--- a/components/MarkDownOnlyContent.vue
+++ b/components/MarkDownOnlyContent.vue
@@ -10,11 +10,11 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { defineComponent, PropOptions } from '@nuxtjs/composition-api';
 import MarkDownContent from '~/components/MarkDownContent';
 import { MarkedOptions } from 'marked';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'MarkDownOnlyContent',
   props: {
     source: {

--- a/components/layouts/PageFooter.vue
+++ b/components/layouts/PageFooter.vue
@@ -32,21 +32,22 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { Link } from '~/types';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
+import { Link, RootState } from '~/types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PageFooter',
-  computed: {
-    allPageLinks (): Link[] {
-      return this.$store.getters['pageLinks/allPageLinks'];
-    },
-    footerTitle (): string {
-      return '© 2019 hiroxto';
-    },
-    footerLinksTitle (): string {
-      return 'Page links';
-    },
+  setup () {
+    const store = useStore<RootState>();
+    const allPageLinks = computed<Link[]>(() => store.getters['pageLinks/allPageLinks']);
+    const footerTitle = computed<string>(() => '© 2019 hiroxto');
+    const footerLinksTitle = computed<string>(() => 'Page links');
+
+    return {
+      allPageLinks,
+      footerTitle,
+      footerLinksTitle,
+    };
   },
 });
 </script>

--- a/components/pages/cl-sound/PlaySound.vue
+++ b/components/pages/cl-sound/PlaySound.vue
@@ -15,27 +15,28 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, computed } from '@nuxtjs/composition-api';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'PlaySound',
-  computed: {
-    audioContext (): AudioContext {
-      return new AudioContext();
-    },
-  },
-  methods: {
-    playSound (): void {
-      const oscillator = this.audioContext.createOscillator();
+  setup () {
+    const audioContext = computed<AudioContext>(() => new AudioContext());
+    const playSound = (): void => {
+      const oscillator = audioContext.value.createOscillator();
       oscillator.type = 'sine';
       oscillator.frequency.value = 1500;
-      oscillator.connect(this.audioContext.destination);
+      oscillator.connect(audioContext.value.destination);
       oscillator.start(0);
 
       window.setTimeout(() => {
         oscillator.stop();
       }, 500);
-    },
+    };
+
+    return {
+      audioContext,
+      playSound,
+    }
   },
 });
 </script>

--- a/components/pages/cl-sound/PlaySound.vue
+++ b/components/pages/cl-sound/PlaySound.vue
@@ -36,7 +36,7 @@ export default defineComponent({
     return {
       audioContext,
       playSound,
-    }
+    };
   },
 });
 </script>

--- a/components/pages/cl-sound/Specification.vue
+++ b/components/pages/cl-sound/Specification.vue
@@ -10,9 +10,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@nuxtjs/composition-api';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'Specification',
 });
 </script>

--- a/components/pages/qr-code/BackGroundField.vue
+++ b/components/pages/qr-code/BackGroundField.vue
@@ -9,19 +9,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
+import { RootState } from '~/types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'BackGroundField',
-  computed: {
-    backGround: {
-      get (): string {
-        return this.$store.state.qrCodeGenerator.backGround;
+  setup () {
+    const store = useStore<RootState>();
+    const backGround = computed({
+      get: (): string => {
+        return store.state.qrCodeGenerator.backGround;
       },
-      set (backGround): void {
-        this.$store.commit('qrCodeGenerator/setBackGround', backGround);
+      set: (val) => {
+        store.commit('qrCodeGenerator/setBackGround', val);
       },
-    },
+    });
+
+    return {
+      backGround,
+    };
   },
 });
 </script>

--- a/components/pages/qr-code/ErrorCorrectionLevelField.vue
+++ b/components/pages/qr-code/ErrorCorrectionLevelField.vue
@@ -23,33 +23,37 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { QrCodeErrorCorrectionLevel } from '~/types';
+import { QrCodeErrorCorrectionLevel, RootState } from '~/types';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
 
 interface ErrorCorrectionLevelFormOption {
   value: QrCodeErrorCorrectionLevel;
   text: string;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ErrorCorrectionLevelField',
-  computed: {
-    level: {
-      get (): string {
-        return this.$store.state.qrCodeGenerator.level;
+  setup () {
+    const store = useStore<RootState>();
+    const level = computed({
+      get: (): string => {
+        return store.state.qrCodeGenerator.level;
       },
-      set (level): void {
-        this.$store.commit('qrCodeGenerator/setLevel', level);
+      set: (val) => {
+        store.commit('qrCodeGenerator/setLevel', val);
       },
-    },
-    levelForms (): ErrorCorrectionLevelFormOption[] {
-      return [
-        { value: 'L', text: 'Level L (7%)' },
-        { value: 'M', text: 'Level M (15%)' },
-        { value: 'Q', text: 'Level Q (25%)' },
-        { value: 'H', text: 'Level H (30%)' },
-      ];
-    },
+    });
+    const levelForms = computed<ErrorCorrectionLevelFormOption[]>(() => [
+      { value: 'L', text: 'Level L (7%)' },
+      { value: 'M', text: 'Level M (15%)' },
+      { value: 'Q', text: 'Level Q (25%)' },
+      { value: 'H', text: 'Level H (30%)' },
+    ]);
+
+    return {
+      level,
+      levelForms,
+    };
   },
 });
 </script>

--- a/components/pages/qr-code/ForeGroundField.vue
+++ b/components/pages/qr-code/ForeGroundField.vue
@@ -9,19 +9,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
+import { RootState } from '~/types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ForeGroundField',
-  computed: {
-    foreGround: {
-      get (): string {
-        return this.$store.state.qrCodeGenerator.foreGround;
+  setup () {
+    const store = useStore<RootState>();
+    const foreGround = computed({
+      get: (): string => {
+        return store.state.qrCodeGenerator.foreGround;
       },
-      set (foreGround): void {
-        this.$store.commit('qrCodeGenerator/setForeGround', foreGround);
+      set: (val) => {
+        store.commit('qrCodeGenerator/setForeGround', val);
       },
-    },
+    });
+
+    return {
+      foreGround,
+    };
   },
 });
 </script>

--- a/components/pages/qr-code/RenderAsField.vue
+++ b/components/pages/qr-code/RenderAsField.vue
@@ -23,31 +23,35 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { QrCodeRenderAsOptionValue } from '~/types';
+import { QrCodeRenderAsOptionValue, RootState } from '~/types';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
 
 interface RenderAsFormOption {
   value: QrCodeRenderAsOptionValue;
   text: string;
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'RenderAsField',
-  computed: {
-    renderAs: {
-      get (): string {
-        return this.$store.state.qrCodeGenerator.renderAs;
+  setup () {
+    const store = useStore<RootState>();
+    const renderAs = computed({
+      get: (): string => {
+        return store.state.qrCodeGenerator.renderAs;
       },
-      set (renderAs): void {
-        this.$store.commit('qrCodeGenerator/setRenderAs', renderAs);
+      set: (val) => {
+        store.commit('qrCodeGenerator/setRenderAs', val);
       },
-    },
-    renderAsForms (): RenderAsFormOption[] {
-      return [
-        { value: 'svg', text: 'SVG' },
-        { value: 'canvas', text: 'Canvas' },
-      ];
-    },
+    });
+    const renderAsForms = computed<RenderAsFormOption[]>(() => [
+      { value: 'svg', text: 'SVG' },
+      { value: 'canvas', text: 'Canvas' },
+    ]);
+
+    return {
+      renderAs,
+      renderAsForms,
+    };
   },
 });
 </script>

--- a/components/pages/qr-code/SizeField.vue
+++ b/components/pages/qr-code/SizeField.vue
@@ -18,22 +18,28 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
+import { RootState } from '~/types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'SizeField',
-  computed: {
-    size: {
-      get (): string {
-        return this.$store.state.qrCodeGenerator.size;
+  setup () {
+    const store = useStore<RootState>();
+    const size = computed({
+      get: (): number => {
+        return store.state.qrCodeGenerator.size;
       },
-      set (size): void {
-        this.$store.commit('qrCodeGenerator/setSize', size);
+      set: (val) => {
+        store.commit('qrCodeGenerator/setSize', val);
       },
-    },
-    sliderTicks (): number[] {
-      return [0, 100, 200, 300, 400, 500];
-    },
+    });
+
+    const sliderTicks = computed<number[]>(() => [0, 100, 200, 300, 400, 500]);
+
+    return {
+      size,
+      sliderTicks,
+    };
   },
 });
 </script>

--- a/components/pages/qr-code/ValueField.vue
+++ b/components/pages/qr-code/ValueField.vue
@@ -9,19 +9,25 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useStore } from '@nuxtjs/composition-api';
+import { RootState } from '~/types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'ValueField',
-  computed: {
-    value: {
-      get (): string {
-        return this.$store.state.qrCodeGenerator.value;
+  setup () {
+    const store = useStore<RootState>();
+    const value = computed({
+      get: () => {
+        return store.state.qrCodeGenerator.value;
       },
-      set (value): void {
-        this.$store.commit('qrCodeGenerator/setValue', value);
+      set: (val) => {
+        store.commit('qrCodeGenerator/setValue', val);
       },
-    },
+    });
+
+    return {
+      value,
+    };
   },
 });
 </script>

--- a/components/pages/train-number-calc/HowToCalc.vue
+++ b/components/pages/train-number-calc/HowToCalc.vue
@@ -41,48 +41,49 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent } from '@nuxtjs/composition-api';
 
 interface FreightHtmlList {
   html: string;
   list?: string[];
 }
 
-export default Vue.extend({
+export default defineComponent({
   name: 'HowToCalc',
-  computed: {
-    passengerHtmlList (): string[] {
-      return [
-        '桁数が1,2,4桁で、4桁のときの百位が<code>0</code>の場合、<strong>特急客</strong>。',
-        '桁数が3,4桁かつ、百位が<code>0</code>以外で下2桁が<code>00〜19</code>の場合、<strong>急客</strong>',
-        '桁数が3,4桁かつ、百位が<code>0</code>以外で下2桁が<code>20〜49</code>の場合、<strong>客</strong>',
-        '千位が<code>6</code>以上の場合は種別の頭に<code>臨</code>が付く。(e.g. <strong>臨特急</strong>, <strong>臨急客</strong>, <strong>臨客</strong>)',
-      ];
-    },
-    freightHtmlList (): FreightHtmlList[] {
-      return [
-        {
-          html: '千位が<code>0～5</code>、百位が<code>0</code>の場合、<strong>高速貨</strong>。下2桁で<strong>高速貨A</strong>と<strong>高速貨B</strong>に分かれる。',
-          list: [
-            '下2桁が<code>50〜69</code>の場合、<strong>高速貨A</strong>。',
-            '下2桁が<code>70〜99</code>の場合、<strong>高速貨B</strong>。',
-          ],
-        },
-        {
-          html: '千位が<code>0,1</code>、百位が<code>1〜9</code>、下2桁が<code>50〜59</code>の場合、<strong>高速貨C</strong>。',
-        },
-        {
-          html: '千位が<code>1,3,4,5</code>、百位が<code>1～9</code>の場合、<strong>専貨</strong>。下2桁で<strong>専貨A</strong>と<strong>専貨B</strong>に分かれる。',
-          list: [
-            '下2桁が<code>60～89</code>の場合、<strong>専貨A</strong>。',
-            '下2桁が<code>90～99</code>の場合、<strong>専貨B</strong>。',
-          ],
-        },
-        {
-          html: '千位が<code>8</code>以上の場合は種別の頭に<code>臨</code>が付く。(e.g. <strong>臨高速貨A</strong>, <strong>臨専貨A</strong>)',
-        },
-      ];
-    },
+  setup () {
+    const passengerHtmlList = computed<string[]>(() => [
+      '桁数が1,2,4桁で、4桁のときの百位が<code>0</code>の場合、<strong>特急客</strong>。',
+      '桁数が3,4桁かつ、百位が<code>0</code>以外で下2桁が<code>00〜19</code>の場合、<strong>急客</strong>',
+      '桁数が3,4桁かつ、百位が<code>0</code>以外で下2桁が<code>20〜49</code>の場合、<strong>客</strong>',
+      '千位が<code>6</code>以上の場合は種別の頭に<code>臨</code>が付く。(e.g. <strong>臨特急</strong>, <strong>臨急客</strong>, <strong>臨客</strong>)',
+    ]);
+    const freightHtmlList = computed<FreightHtmlList[]>(() => [
+      {
+        html: '千位が<code>0～5</code>、百位が<code>0</code>の場合、<strong>高速貨</strong>。下2桁で<strong>高速貨A</strong>と<strong>高速貨B</strong>に分かれる。',
+        list: [
+          '下2桁が<code>50〜69</code>の場合、<strong>高速貨A</strong>。',
+          '下2桁が<code>70〜99</code>の場合、<strong>高速貨B</strong>。',
+        ],
+      },
+      {
+        html: '千位が<code>0,1</code>、百位が<code>1〜9</code>、下2桁が<code>50〜59</code>の場合、<strong>高速貨C</strong>。',
+      },
+      {
+        html: '千位が<code>1,3,4,5</code>、百位が<code>1～9</code>の場合、<strong>専貨</strong>。下2桁で<strong>専貨A</strong>と<strong>専貨B</strong>に分かれる。',
+        list: [
+          '下2桁が<code>60～89</code>の場合、<strong>専貨A</strong>。',
+          '下2桁が<code>90～99</code>の場合、<strong>専貨B</strong>。',
+        ],
+      },
+      {
+        html: '千位が<code>8</code>以上の場合は種別の頭に<code>臨</code>が付く。(e.g. <strong>臨高速貨A</strong>, <strong>臨専貨A</strong>)',
+      },
+    ]);
+
+    return {
+      passengerHtmlList,
+      freightHtmlList,
+    };
   },
 });
 </script>

--- a/components/pages/train-number-calc/NumberCalc.vue
+++ b/components/pages/train-number-calc/NumberCalc.vue
@@ -35,12 +35,12 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import { ValidationProvider, extend, localize } from 'vee-validate';
 import { numeric, between } from 'vee-validate/dist/rules';
 import ja from 'vee-validate/dist/locale/ja.json';
 import TrainNumberCalc from '~/lib/TrainNumberCalc';
 import { TrainNumberType } from '~/types';
+import { computed, defineComponent, ref } from '@nuxtjs/composition-api';
 
 ja.messages['not-starts-with-zero'] = '{_field_}は不正な値です。';
 extend('numeric', numeric);
@@ -59,31 +59,25 @@ localize('ja', {
   messages: ja.messages,
 });
 
-export default Vue.extend({
+export default defineComponent({
   name: 'NumberCalc',
-  data () {
+  setup () {
+    const trainNumber = ref('');
+    const numberCalc = computed<TrainNumberCalc>(() => new TrainNumberCalc(trainNumber.value));
+    const trainType = computed<TrainNumberType|null>(() => numberCalc.value.calc());
+    const isRenderTrainType = computed<boolean>(() => (trainType.value !== null));
+    const getInputClass = (errors: string[]): string => errors.length === 0 ? 'is-success' : 'is-danger';
+
     return {
-      trainNumber: '',
+      trainNumber,
+      numberCalc,
+      trainType,
+      isRenderTrainType,
+      getInputClass,
     };
   },
   components: {
     ValidationProvider,
-  },
-  computed: {
-    numberCalc (): TrainNumberCalc {
-      return new TrainNumberCalc(this.trainNumber);
-    },
-    trainType (): TrainNumberType|null {
-      return this.numberCalc.calc();
-    },
-    isRenderTrainType (): boolean {
-      return this.trainType !== null;
-    },
-  },
-  methods: {
-    getInputClass (errors: string[]): string {
-      return errors.length === 0 ? 'is-success' : 'is-danger';
-    },
   },
 });
 </script>

--- a/components/pages/train-number/TrainNumberPage.vue
+++ b/components/pages/train-number/TrainNumberPage.vue
@@ -4,32 +4,39 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, PropType, useMeta } from '@nuxtjs/composition-api';
 import MarkDownOnlyContent from '~/components/MarkDownOnlyContent';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'TrainNumberPage',
-  components: {
-    MarkDownOnlyContent,
+  props: {
+    title: {
+      required: true,
+      type: String,
+    } as PropType<string>,
+    source: {
+      required: true,
+      type: String,
+    } as PropType<string>,
   },
-  head () {
-    return {
-      title: this.title,
+  head: {},
+  setup (props) {
+    const title = props.title;
+    const description = computed<string>(() => `列車番号メモ ${title}`);
+
+    useMeta(() => ({
+      title: title,
       meta: [
-        { hid: 'description', name: 'description', content: this.description },
+        { hid: 'description', name: 'description', content: description.value },
       ],
+    }));
+
+    return {
+      description,
     };
   },
-  computed: {
-    title (): string {
-      return 'title';
-    },
-    description (): string {
-      return `列車番号メモ ${this.title}`;
-    },
-    source (): string {
-      return '';
-    },
+  components: {
+    MarkDownOnlyContent,
   },
 });
 </script>

--- a/components/ui/LinksMenu.vue
+++ b/components/ui/LinksMenu.vue
@@ -20,10 +20,10 @@
 </template>
 
 <script lang="ts">
-import Vue, { PropOptions } from 'vue';
+import { defineComponent, PropOptions } from '@nuxtjs/composition-api';
 import { Link } from '~/types';
 
-export default Vue.extend({
+export default defineComponent({
   name: 'LinksMenu',
   props: {
     links: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,10 +10,10 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@nuxtjs/composition-api';
 import PageFooter from '~/components/layouts/PageFooter';
 
-export default Vue.extend({
+export default defineComponent({
   components: {
     PageFooter,
   },

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   command = "yarn run generate"
 
 [build.environment]
-  NODE_VERSION = "12.18.1"
+  NODE_VERSION = "14.17.4"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,6 +53,8 @@ const nuxtConfig: Configuration = {
     }],
 
     '@nuxtjs/eslint-module',
+
+    '@nuxtjs/composition-api/module',
   ],
 
   /*

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@nuxt/typescript-runtime": "2.1.0",
+    "@nuxtjs/composition-api": "^0.26.0",
     "cross-env": "7.0.3",
     "nuxt": "2.15.7",
     "nuxt-buefy": "0.4.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@nuxt/typescript-runtime": "2.1.0",
-    "@nuxtjs/composition-api": "^0.26.0",
     "cross-env": "7.0.3",
     "nuxt": "2.15.7",
     "nuxt-buefy": "0.4.8",

--- a/pages/cl-sound/index.vue
+++ b/pages/cl-sound/index.vue
@@ -19,30 +19,31 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent, computed, useMeta } from '@nuxtjs/composition-api';
 import PlaySound from '~/components/pages/cl-sound/PlaySound';
 import Specification from '~/components/pages/cl-sound/Specification';
 
-export default Vue.extend({
-  head () {
-    return {
-      title: this.title,
+export default defineComponent({
+  head: {},
+  setup () {
+    const title = computed<string>(() => 'EMVコンタクトレスのサウンドをWeb Audio APIで再生');
+    const description = computed<string>(() => 'EMVコンタクトレスのサウンドをWeb Audio APIで再生');
+
+    useMeta(() => ({
+      title: title.value,
       meta: [
-        { hid: 'description', name: 'description', content: this.description },
+        { hid: 'description', name: 'description', content: description.value },
       ],
+    }));
+
+    return {
+      title,
+      description,
     };
   },
   components: {
     PlaySound,
     Specification,
-  },
-  computed: {
-    title (): string {
-      return 'EMVコンタクトレスのサウンドをWeb Audio APIで再生';
-    },
-    description (): string {
-      return 'EMVコンタクトレスのサウンドをWeb Audio APIで再生';
-    },
   },
 });
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,33 +14,34 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useMeta, useStore } from '@nuxtjs/composition-api';
 import LinksMenu from '~/components/ui/LinksMenu';
-import { Link } from '~/types';
+import { Link, PageLinksState } from '~/types';
 
-export default Vue.extend({
-  head () {
-    return {
-      title: this.title,
+export default defineComponent({
+  head: {},
+  setup () {
+    const title = computed<string>(() => 'utils.hiroxto.net');
+    const description = computed<string>(() => 'Utility site for me.');
+    const linksStore = useStore<PageLinksState>();
+    const pageLinks = computed<Link[]>(() => linksStore.getters['pageLinks/pageLinks']);
+
+    useMeta(() => ({
+      title: title.value,
       titleTemplate: '',
       meta: [
-        { hid: 'description', name: 'description', content: this.description },
+        { hid: 'description', name: 'description', content: description.value },
       ],
+    }));
+
+    return {
+      title,
+      description,
+      pageLinks,
     };
   },
   components: {
     LinksMenu,
-  },
-  computed: {
-    pageLinks (): Link[] {
-      return this.$store.getters['pageLinks/pageLinks'];
-    },
-    title (): string {
-      return 'utils.hiroxto.net';
-    },
-    description (): string {
-      return 'Utility site for me.';
-    },
   },
 });
 </script>

--- a/pages/qr-code/index.vue
+++ b/pages/qr-code/index.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useMeta, useStore } from '@nuxtjs/composition-api';
 import QrCodeVue from 'qrcode.vue';
 import ValueField from '~/components/pages/qr-code/ValueField';
 import SizeField from '~/components/pages/qr-code/SizeField';
@@ -52,15 +52,38 @@ import ErrorCorrectionLevelField from '~/components/pages/qr-code/ErrorCorrectio
 import RenderAsField from '~/components/pages/qr-code/RenderAsField';
 import BackGroundField from '~/components/pages/qr-code/BackGroundField';
 import ForeGroundField from '~/components/pages/qr-code/ForeGroundField';
-import { QrCodeErrorCorrectionLevel, QrCodeRenderAsOptionValue } from '~/types';
+import { QrCodeErrorCorrectionLevel, QrCodeRenderAsOptionValue, RootState } from '~/types';
 
-export default Vue.extend({
-  head () {
-    return {
-      title: this.title,
+export default defineComponent({
+  head: {},
+  setup () {
+    const title = computed<string>(() => 'QRコード生成');
+    const description = computed<string>(() => 'ブラウザでQRコードを生成．');
+
+    useMeta(() => ({
+      title: title.value,
       meta: [
-        { hid: 'description', name: 'description', content: this.description },
+        { hid: 'description', name: 'description', content: description.value },
       ],
+    }));
+
+    const store = useStore<RootState>();
+    const value = computed<string>(() => store.state.qrCodeGenerator.value);
+    const size = computed<number>(() => store.state.qrCodeGenerator.size);
+    const level = computed<QrCodeErrorCorrectionLevel>(() => store.state.qrCodeGenerator.level);
+    const renderAs = computed<QrCodeRenderAsOptionValue>(() => store.state.qrCodeGenerator.renderAs);
+    const backGround = computed<string>(() => store.state.qrCodeGenerator.backGround);
+    const foreGround = computed<string>(() => store.state.qrCodeGenerator.foreGround);
+
+    return {
+      title,
+      description,
+      value,
+      size,
+      level,
+      renderAs,
+      backGround,
+      foreGround,
     };
   },
   components: {
@@ -71,32 +94,6 @@ export default Vue.extend({
     RenderAsField,
     BackGroundField,
     ForeGroundField,
-  },
-  computed: {
-    title (): string {
-      return 'QRコード生成';
-    },
-    description (): string {
-      return 'ブラウザでQRコードを生成。';
-    },
-    value (): string {
-      return this.$store.state.qrCodeGenerator.value;
-    },
-    size (): number {
-      return this.$store.state.qrCodeGenerator.size;
-    },
-    level (): QrCodeErrorCorrectionLevel {
-      return this.$store.state.qrCodeGenerator.level;
-    },
-    renderAs (): QrCodeRenderAsOptionValue {
-      return this.$store.state.qrCodeGenerator.renderAs;
-    },
-    backGround (): string {
-      return this.$store.state.qrCodeGenerator.backGround;
-    },
-    foreGround (): string {
-      return this.$store.state.qrCodeGenerator.foreGround;
-    },
   },
 });
 </script>

--- a/pages/train-number-calc/index.vue
+++ b/pages/train-number-calc/index.vue
@@ -19,30 +19,31 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
 import NumberCalc from '~/components/pages/train-number-calc/NumberCalc';
 import HowToCalc from '~/components/pages/train-number-calc/HowToCalc';
+import { computed, defineComponent, useMeta } from '@nuxtjs/composition-api';
 
-export default Vue.extend({
-  head () {
-    return {
-      title: this.title,
+export default defineComponent({
+  head: {},
+  setup () {
+    const title = computed<string>(() => '列車番号から列車種別を計算');
+    const description = computed<string>(() => '列車番号から列車種別(特急客, 臨急客, 臨特急客, 高速貨A, 臨専貨A, など)を計算できるページ．');
+
+    useMeta(() => ({
+      title: title.value,
       meta: [
-        { hid: 'description', name: 'description', content: this.description },
+        { hid: 'description', name: 'description', content: description.value },
       ],
+    }));
+
+    return {
+      title,
+      description,
     };
   },
   components: {
     NumberCalc,
     HowToCalc,
-  },
-  computed: {
-    title (): string {
-      return '列車番号から列車種別を計算';
-    },
-    description (): string {
-      return '列車番号から列車種別(特急客, 臨急客, 臨特急客, 高速貨A, 臨専貨A, など)を計算できるページ。';
-    },
   },
 });
 </script>

--- a/pages/train-number/2018-03-17.vue
+++ b/pages/train-number/2018-03-17.vue
@@ -1,16 +1,29 @@
+<template>
+  <train-number-page
+    :title="title"
+    :source="source"
+  >
+  </train-number-page>
+</template>
+
 <script lang="ts">
+import { computed, defineComponent } from '@nuxtjs/composition-api';
 import TrainNumberPage from '~/components/pages/train-number/TrainNumberPage';
 import contentSource from '~/assets/train-number/2018-03-17.md';
 
-export default TrainNumberPage.extend({
+export default defineComponent({
   name: 'TrainNumber20180317Page',
-  computed: {
-    title (): string {
-      return '2018年3月17日 改正';
-    },
-    source (): string {
-      return contentSource;
-    },
+  components: {
+    TrainNumberPage,
+  },
+  setup () {
+    const title = computed<string>(() => '2018年3月17日 改正');
+    const source = computed<string>(() => contentSource);
+
+    return {
+      title,
+      source,
+    };
   },
 });
 </script>

--- a/pages/train-number/2019-03-16.vue
+++ b/pages/train-number/2019-03-16.vue
@@ -1,16 +1,29 @@
+<template>
+  <train-number-page
+    :title="title"
+    :source="source"
+  >
+  </train-number-page>
+</template>
+
 <script lang="ts">
+import { computed, defineComponent } from '@nuxtjs/composition-api';
 import TrainNumberPage from '~/components/pages/train-number/TrainNumberPage';
 import contentSource from '~/assets/train-number/2019-03-16.md';
 
-export default TrainNumberPage.extend({
-  name: 'TrainNumber20190316Page',
-  computed: {
-    title (): string {
-      return '2019年3月16日 改正';
-    },
-    source (): string {
-      return contentSource;
-    },
+export default defineComponent({
+  name: 'TrainNumber20180317Page',
+  components: {
+    TrainNumberPage,
+  },
+  setup () {
+    const title = computed<string>(() => '2019年3月16日 改正');
+    const source = computed<string>(() => contentSource);
+
+    return {
+      title,
+      source,
+    };
   },
 });
 </script>

--- a/pages/train-number/index.vue
+++ b/pages/train-number/index.vue
@@ -19,6 +19,7 @@ import LinksMenu from '~/components/ui/LinksMenu';
 import { Link, RootState } from '~/types';
 
 export default defineComponent({
+  head: {},
   setup () {
     const store = useStore<RootState>();
     const title = computed<string>(() => '列車番号メモ');

--- a/pages/train-number/index.vue
+++ b/pages/train-number/index.vue
@@ -14,32 +14,32 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { computed, defineComponent, useMeta, useStore } from '@nuxtjs/composition-api';
 import LinksMenu from '~/components/ui/LinksMenu';
-import { Link } from '~/types';
+import { Link, RootState } from '~/types';
 
-export default Vue.extend({
-  head () {
-    return {
-      title: this.title,
+export default defineComponent({
+  setup () {
+    const store = useStore<RootState>();
+    const title = computed<string>(() => '列車番号メモ');
+    const description = computed<string>(() => '入出場，車輪転削などの予定臨や，パターンが概ね決まっている臨工や臨単の列車番号のメモ．');
+    const trainNumberContentPageLinks = computed<Link[]>(() => store.getters['pageLinks/trainNumberContentPageLinks']);
+
+    useMeta(() => ({
+      title: title.value,
       meta: [
-        { hid: 'description', name: 'description', content: this.description },
+        { hid: 'description', name: 'description', content: description.value },
       ],
+    }));
+
+    return {
+      title,
+      description,
+      trainNumberContentPageLinks,
     };
   },
   components: {
     LinksMenu,
-  },
-  computed: {
-    trainNumberContentPageLinks (): Link[] {
-      return this.$store.getters['pageLinks/trainNumberContentPageLinks'];
-    },
-    title (): string {
-      return '列車番号メモ';
-    },
-    description (): string {
-      return '入出場,車輪転削などの予定臨や、パターンが概ね決まっている臨工や臨単の列車番号のメモ。';
-    },
   },
 });
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,6 +1333,19 @@
     webpack-node-externals "^3.0.0"
     webpackbar "^4.0.0"
 
+"@nuxtjs/composition-api@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/composition-api/-/composition-api-0.26.0.tgz#0fbda4fc942ca1e346b7c6d55a1fb331ff931a2a"
+  integrity sha512-+4L9YDEN5h/vBY6xbBKPMIhgxbPv7psE4IVgKlF+QIekou6oN8m0T+QR2JLE0dHKwzicUbZLCr1v2Qw5T7L48A==
+  dependencies:
+    "@vue/composition-api" "^1.0.4"
+    defu "^5.0.0"
+    estree-walker "^2.0.2"
+    fs-extra "^9.1.0"
+    magic-string "^0.25.7"
+    ufo "^0.7.7"
+    upath "^2.0.1"
+
 "@nuxtjs/eslint-module@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-module/-/eslint-module-3.0.2.tgz#45208e6e1b486beb6d0854777faf124751971bc6"
@@ -1888,6 +1901,13 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
+
+"@vue/composition-api@^1.0.4":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.5.tgz#c7cef457284096e75cc0894e0cb9a251f91eba3f"
+  integrity sha512-F5jZiSTFvpnJD4geVc5KNY4eNS5NrfU/nZXachzxYorl56SDlh54rFVRm1QtXgdTj/kwvgixT4n0XfhZZpnoBA==
+  dependencies:
+    tslib "^2.3.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4174,6 +4194,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5816,6 +5841,13 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -8498,6 +8530,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -9097,7 +9134,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
@@ -9173,7 +9210,7 @@ ua-parser-js@^0.7.28:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
-ufo@^0.7.4:
+ufo@^0.7.4, ufo@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.7.tgz#0062f9e5e790819b0fb23ca24d7c63a4011c036a"
   integrity sha512-N25aY3HBkJBnahm+2l4JRBBrX5I+JPakF/tDHYDTjd3wUR7iFLdyiPhj8mBwBz21v728BKwM9L9tgBfCntgdlw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,25 +16,25 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
-"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.0", "@babel/compat-data@^7.14.5", "@babel/compat-data@^7.14.7", "@babel/compat-data@^7.14.9":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.9.tgz#ac7996ceaafcf8f410119c8af0d1db4cf914a210"
-  integrity sha512-p3QjZmMGHDGdpcwEYYWu7i7oJShJvtgMjJeb0W95PPhSm++3lm8YXYOh45Y6iCN9PkZLTZ7CIX5nFrp7pw7TXw==
+"@babel/compat-data@^7.13.11", "@babel/compat-data@^7.14.0", "@babel/compat-data@^7.14.7", "@babel/compat-data@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
+  integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
 "@babel/core@^7.14.0":
-  version "7.14.8"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.8.tgz#20cdf7c84b5d86d83fac8710a8bc605a7ba3f010"
-  integrity sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.0.tgz#749e57c68778b73ad8082775561f67f5196aafa8"
+  integrity sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==
   dependencies:
     "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.8"
-    "@babel/helper-compilation-targets" "^7.14.5"
-    "@babel/helper-module-transforms" "^7.14.8"
+    "@babel/generator" "^7.15.0"
+    "@babel/helper-compilation-targets" "^7.15.0"
+    "@babel/helper-module-transforms" "^7.15.0"
     "@babel/helpers" "^7.14.8"
-    "@babel/parser" "^7.14.8"
+    "@babel/parser" "^7.15.0"
     "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.8"
-    "@babel/types" "^7.14.8"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -42,12 +42,12 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.8", "@babel/generator@^7.14.9":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.9.tgz#23b19c597d38b4f7dc2e3fe42a69c88d9ecfaa16"
-  integrity sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==
+"@babel/generator@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.0.tgz#a7d0c172e0d814974bad5aa77ace543b97917f15"
+  integrity sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
   dependencies:
-    "@babel/types" "^7.14.9"
+    "@babel/types" "^7.15.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -66,26 +66,26 @@
     "@babel/helper-explode-assignable-expression" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.16", "@babel/helper-compilation-targets@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
-  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
+"@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.13.16", "@babel/helper-compilation-targets@^7.14.5", "@babel/helper-compilation-targets@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz#973df8cbd025515f3ff25db0c05efc704fa79818"
+  integrity sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==
   dependencies:
-    "@babel/compat-data" "^7.14.5"
+    "@babel/compat-data" "^7.15.0"
     "@babel/helper-validator-option" "^7.14.5"
     browserslist "^4.16.6"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.14.5":
-  version "7.14.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.8.tgz#a6f8c3de208b1e5629424a9a63567f56501955fc"
-  integrity sha512-bpYvH8zJBWzeqi1o+co8qOrw+EXzQ/0c74gVmY205AWXy9nifHrOg77y+1zwxX5lXE7Icq4sPlSQ4O2kWBrteQ==
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz#c9a137a4d137b2d0e2c649acf536d7ba1a76c0f7"
+  integrity sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.14.5"
     "@babel/helper-function-name" "^7.14.5"
-    "@babel/helper-member-expression-to-functions" "^7.14.7"
+    "@babel/helper-member-expression-to-functions" "^7.15.0"
     "@babel/helper-optimise-call-expression" "^7.14.5"
-    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.15.0"
     "@babel/helper-split-export-declaration" "^7.14.5"
 
 "@babel/helper-create-regexp-features-plugin@^7.14.5":
@@ -140,12 +140,12 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-member-expression-to-functions@^7.14.5", "@babel/helper-member-expression-to-functions@^7.14.7":
-  version "7.14.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
-  integrity sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==
+"@babel/helper-member-expression-to-functions@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz#0ddaf5299c8179f27f37327936553e9bba60990b"
+  integrity sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==
   dependencies:
-    "@babel/types" "^7.14.5"
+    "@babel/types" "^7.15.0"
 
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12", "@babel/helper-module-imports@^7.14.5":
   version "7.14.5"
@@ -154,19 +154,19 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-module-transforms@^7.14.5", "@babel/helper-module-transforms@^7.14.8":
-  version "7.14.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz#d4279f7e3fd5f4d5d342d833af36d4dd87d7dc49"
-  integrity sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==
+"@babel/helper-module-transforms@^7.14.5", "@babel/helper-module-transforms@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz#679275581ea056373eddbe360e1419ef23783b08"
+  integrity sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==
   dependencies:
     "@babel/helper-module-imports" "^7.14.5"
-    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.15.0"
     "@babel/helper-simple-access" "^7.14.8"
     "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/helper-validator-identifier" "^7.14.8"
+    "@babel/helper-validator-identifier" "^7.14.9"
     "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.8"
-    "@babel/types" "^7.14.8"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
 
 "@babel/helper-optimise-call-expression@^7.14.5":
   version "7.14.5"
@@ -189,17 +189,17 @@
     "@babel/helper-wrap-function" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/helper-replace-supers@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
-  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
+"@babel/helper-replace-supers@^7.14.5", "@babel/helper-replace-supers@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz#ace07708f5bf746bf2e6ba99572cce79b5d4e7f4"
+  integrity sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-member-expression-to-functions" "^7.15.0"
     "@babel/helper-optimise-call-expression" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
+    "@babel/traverse" "^7.15.0"
+    "@babel/types" "^7.15.0"
 
-"@babel/helper-simple-access@^7.14.5", "@babel/helper-simple-access@^7.14.8":
+"@babel/helper-simple-access@^7.14.8":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz#82e1fec0644a7e775c74d305f212c39f8fe73924"
   integrity sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==
@@ -220,7 +220,7 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.8", "@babel/helper-validator-identifier@^7.14.9":
+"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
   integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
@@ -258,10 +258,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.8", "@babel/parser@^7.14.9":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.9.tgz#596c1ad67608070058ebf8df50c1eaf65db895a4"
-  integrity sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.0.tgz#b6d6e29058ca369127b0eeca2a1c4b5794f1b6b9"
+  integrity sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -639,14 +639,14 @@
     "@babel/helper-plugin-utils" "^7.14.5"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.5.tgz#7aaee0ea98283de94da98b28f8c35701429dad97"
-  integrity sha512-en8GfBtgnydoao2PS+87mKyw62k02k7kJ9ltbKe0fXTHrQmG6QZZflYuGI1VVG7sVpx4E1n7KBpNlPb8m78J+A==
+"@babel/plugin-transform-modules-commonjs@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.0.tgz#3305896e5835f953b5cdb363acd9e8c2219a5281"
+  integrity sha512-3H/R9s8cXcOGE8kgMlmjYYC9nqr5ELiPkJn4q0mypBrjhYQoc+5/Maq69vV4xRPWnkzZuwJPf5rArxpB/35Cig==
   dependencies:
-    "@babel/helper-module-transforms" "^7.14.5"
+    "@babel/helper-module-transforms" "^7.15.0"
     "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/helper-simple-access" "^7.14.5"
+    "@babel/helper-simple-access" "^7.14.8"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-modules-systemjs@^7.14.5":
@@ -719,9 +719,9 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-runtime@^7.13.15":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.5.tgz#30491dad49c6059f8f8fa5ee8896a0089e987523"
-  integrity sha512-fPMBhh1AV8ZyneiCIA+wYYUH1arzlXR1UMcApjvchDhfKxhy2r2lReJv8uHEyihi4IFIGlr1Pdx7S5fkESDQsg==
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.15.0.tgz#d3aa650d11678ca76ce294071fda53d7804183b3"
+  integrity sha512-sfHYkLGjhzWTq6xsuQ01oEsUYjkHRux9fW1iUA68dC7Qd8BS1Unq4aZ8itmQp95zUzIcyR2EbNMTzAicFj+guw==
   dependencies:
     "@babel/helper-module-imports" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
@@ -782,12 +782,12 @@
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/preset-env@^7.14.1":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.9.tgz#4a3bbbd745f20e9121d5925170bef040a21b7819"
-  integrity sha512-BV5JvCwBDebkyh67bPKBYVCC6gGw0MCzU6HfKe5Pm3upFpPVqiC/hB33zkOe0tVdAzaMywah0LSXQeD9v/BYdQ==
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.15.0.tgz#e2165bf16594c9c05e52517a194bf6187d6fe464"
+  integrity sha512-FhEpCNFCcWW3iZLg0L2NPE9UerdtsCR6ZcsGHUX6Om6kbCQeL5QZDqFDmeNHC6/fy6UH3jEge7K4qG5uC9In0Q==
   dependencies:
-    "@babel/compat-data" "^7.14.9"
-    "@babel/helper-compilation-targets" "^7.14.5"
+    "@babel/compat-data" "^7.15.0"
+    "@babel/helper-compilation-targets" "^7.15.0"
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/helper-validator-option" "^7.14.5"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.14.5"
@@ -835,7 +835,7 @@
     "@babel/plugin-transform-literals" "^7.14.5"
     "@babel/plugin-transform-member-expression-literals" "^7.14.5"
     "@babel/plugin-transform-modules-amd" "^7.14.5"
-    "@babel/plugin-transform-modules-commonjs" "^7.14.5"
+    "@babel/plugin-transform-modules-commonjs" "^7.15.0"
     "@babel/plugin-transform-modules-systemjs" "^7.14.5"
     "@babel/plugin-transform-modules-umd" "^7.14.5"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.14.9"
@@ -853,7 +853,7 @@
     "@babel/plugin-transform-unicode-escapes" "^7.14.5"
     "@babel/plugin-transform-unicode-regex" "^7.14.5"
     "@babel/preset-modules" "^0.1.4"
-    "@babel/types" "^7.14.9"
+    "@babel/types" "^7.15.0"
     babel-plugin-polyfill-corejs2 "^0.2.2"
     babel-plugin-polyfill-corejs3 "^0.2.2"
     babel-plugin-polyfill-regenerator "^0.2.2"
@@ -887,25 +887,25 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.14.8":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.9.tgz#016126b331210bf06fff29d52971eef8383e556f"
-  integrity sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==
+"@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.14.8", "@babel/traverse@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.0.tgz#4cca838fd1b2a03283c1f38e141f639d60b3fc98"
+  integrity sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
   dependencies:
     "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.9"
+    "@babel/generator" "^7.15.0"
     "@babel/helper-function-name" "^7.14.5"
     "@babel/helper-hoist-variables" "^7.14.5"
     "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/parser" "^7.14.9"
-    "@babel/types" "^7.14.9"
+    "@babel/parser" "^7.15.0"
+    "@babel/types" "^7.15.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.14.9", "@babel/types@^7.3.0", "@babel/types@^7.4.4":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.9.tgz#f2b19c3f2f77c5708d67fe8f6046e9cea2b5036d"
-  integrity sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==
+"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.14.8", "@babel/types@^7.15.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
+  integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
@@ -1541,9 +1541,9 @@
     "@types/uglify-js" "*"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
-  integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
 "@types/less@3.0.2":
   version "3.0.2"
@@ -1573,9 +1573,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "16.4.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.9.tgz#04eb3da65d08ea377f5e682bf0d22dc1f5e7f19e"
-  integrity sha512-HXhRf581nCItzn8yevv4LYt+bJ5cBbDBAJExbDPMeU/2n5/j0ZemGpayahFBP4xL7RseaCLASLD9i9AYyDe7Nw==
+  version "16.4.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.4.12.tgz#961e3091f263e6345d2d84afab4e047a60b4b11b"
+  integrity sha512-zxrTNFl9Z8boMJXs6ieqZP0wAhvkdzmHSxTlJabM16cf5G9xBc1uPRH5Bbv2omEDDiM8MzTfqTJXBf0Ba4xFWA==
 
 "@types/node@12.20.12":
   version "12.20.12"
@@ -2627,15 +2627,15 @@ browserify-zlib@^0.2.0:
     pako "~1.0.5"
 
 browserslist@*, browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.16.6, browserslist@^4.6.4:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
-  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+  version "4.16.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.7.tgz#108b0d1ef33c4af1b587c54f390e7041178e4335"
+  integrity sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==
   dependencies:
-    caniuse-lite "^1.0.30001219"
+    caniuse-lite "^1.0.30001248"
     colorette "^1.2.2"
-    electron-to-chromium "^1.3.723"
+    electron-to-chromium "^1.3.793"
     escalade "^3.1.1"
-    node-releases "^1.1.71"
+    node-releases "^1.1.73"
 
 buefy@^0.9.8:
   version "0.9.8"
@@ -2839,10 +2839,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
-  version "1.0.30001248"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz#26ab45e340f155ea5da2920dadb76a533cb8ebce"
-  integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001248:
+  version "1.0.30001249"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz#90a330057f8ff75bfe97a94d047d5e14fabb2ee8"
+  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3811,10 +3811,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.723:
-  version "1.3.792"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.792.tgz#791b0d8fcf7411885d086193fb49aaef0c1594ca"
-  integrity sha512-RM2O2xrNarM7Cs+XF/OE2qX/aBROyOZqqgP+8FXMXSuWuUqCfUUzg7NytQrzZU3aSqk1Qq6zqnVkJsbfMkIatg==
+electron-to-chromium@^1.3.793:
+  version "1.3.796"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz#bd74a4367902c9d432d129f265bf4542cddd9f54"
+  integrity sha512-agwJFgM0FUC1UPPbQ4aII3HamaaJ09fqWGAWYHmzxDWqdmTleCHyyA0kt3fJlTd5M440IaeuBfzXzXzCotnZcQ==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -3904,9 +3904,9 @@ error-stack-parser@^2.0.0:
     stackframe "^1.1.1"
 
 es-abstract@^1.17.2, es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-abstract@^1.18.2:
-  version "1.18.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.4.tgz#c6b7a1acd6bb1c8b5afeb54a53c46ad02fab346d"
-  integrity sha512-xjDAPJRxKc1uoTkdW8MEk7Fq/2bzz3YoCADYniDV7+KITCUdu9c90fj1aKI7nEZFZxRrHlDo3wtma/C6QkhlXQ==
+  version "1.18.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.5.tgz#9b10de7d4c206a3581fd5b2124233e04db49ae19"
+  integrity sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -4505,9 +4505,9 @@ forever-agent@~0.6.1:
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 fork-ts-checker-webpack-plugin@^6.1.1:
-  version "6.2.13"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.13.tgz#ee90a21c36d794eca481991a4233bbed6dc703d5"
-  integrity sha512-+j/DfwevcZeSXn5WOv32c/shbcbhcKi88asC2A4TDPtURS3MW/qXiVucGiL1PXdt9PCGB88R3BfaSWZ1C/XGHA==
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.3.1.tgz#938535f844cdddf6796211e5761da27341b9fcd3"
+  integrity sha512-uxqlKTEeSJ5/JRr0zaCiw2U+kOV8F4/MhCnnRf6vbxj4ZU3Or0DLl/0CNtXro7uLWDssnuR7wUN7fU9w1I0REA==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@types/json-schema" "^7.0.5"
@@ -4776,9 +4776,9 @@ globule@^1.0.0:
     minimatch "~3.0.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
-  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.7.tgz#ed65e76e7c700c3e2c889ca65677ec0d210db1b3"
+  integrity sha512-b1suB8r7mlSJQIBs6typf13fz55WYPeE7/KYlQUvqB7E3hUkXhz4D8FVHkENHTqG8+mD2yyT9HgT5bNkGNiqeQ==
 
 gzip-size@^6.0.0:
   version "6.0.0"
@@ -6213,9 +6213,9 @@ mute-stream@0.0.8:
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.12.1, nan@^2.13.2:
-  version "2.14.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
-  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nanoid@^3.1.23:
   version "3.1.23"
@@ -6332,7 +6332,7 @@ node-object-hash@^1.2.0:
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-1.4.2.tgz#385833d85b229902b75826224f6077be969a9e94"
   integrity sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ==
 
-node-releases@^1.1.71:
+node-releases@^1.1.73:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
@@ -8892,9 +8892,9 @@ tapable@^1.0.0, tapable@^1.0.0-beta.5, tapable@^1.1.3:
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
 tar@^6.0.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.2.tgz#1f045a90a6eb23557a603595f41a16c57d47adc6"
-  integrity sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
+  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
@@ -9487,9 +9487,9 @@ vue-hot-reload-api@^2.3.0:
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
 vue-loader@^15.9.7:
-  version "15.9.7"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.7.tgz#15b05775c3e0c38407679393c2ce6df673b01044"
-  integrity sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==
+  version "15.9.8"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.8.tgz#4b0f602afaf66a996be1e534fb9609dc4ab10e61"
+  integrity sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==
   dependencies:
     "@vue/component-compiler-utils" "^3.1.0"
     hash-sum "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,19 +1333,6 @@
     webpack-node-externals "^3.0.0"
     webpackbar "^4.0.0"
 
-"@nuxtjs/composition-api@^0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/composition-api/-/composition-api-0.26.0.tgz#0fbda4fc942ca1e346b7c6d55a1fb331ff931a2a"
-  integrity sha512-+4L9YDEN5h/vBY6xbBKPMIhgxbPv7psE4IVgKlF+QIekou6oN8m0T+QR2JLE0dHKwzicUbZLCr1v2Qw5T7L48A==
-  dependencies:
-    "@vue/composition-api" "^1.0.4"
-    defu "^5.0.0"
-    estree-walker "^2.0.2"
-    fs-extra "^9.1.0"
-    magic-string "^0.25.7"
-    ufo "^0.7.7"
-    upath "^2.0.1"
-
 "@nuxtjs/eslint-module@3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-module/-/eslint-module-3.0.2.tgz#45208e6e1b486beb6d0854777faf124751971bc6"
@@ -1901,13 +1888,6 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
-
-"@vue/composition-api@^1.0.4":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.5.tgz#c7cef457284096e75cc0894e0cb9a251f91eba3f"
-  integrity sha512-F5jZiSTFvpnJD4geVc5KNY4eNS5NrfU/nZXachzxYorl56SDlh54rFVRm1QtXgdTj/kwvgixT4n0XfhZZpnoBA==
-  dependencies:
-    tslib "^2.3.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4194,11 +4174,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
-estree-walker@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
-
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -5841,13 +5816,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-magic-string@^0.25.7:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
-  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
-  dependencies:
-    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -8530,11 +8498,6 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
-  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
-
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -9134,7 +9097,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.3.0:
+tslib@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
@@ -9210,7 +9173,7 @@ ua-parser-js@^0.7.28:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
 
-ufo@^0.7.4, ufo@^0.7.7:
+ufo@^0.7.4:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.7.tgz#0062f9e5e790819b0fb23ca24d7c63a4011c036a"
   integrity sha512-N25aY3HBkJBnahm+2l4JRBBrX5I+JPakF/tDHYDTjd3wUR7iFLdyiPhj8mBwBz21v728BKwM9L9tgBfCntgdlw==


### PR DESCRIPTION
# 概要

Vue SFCの実装方法をComposition APIに移行．
全てのコンポーネントをComposition APIで書き直した．

列番メモのページはTrainNumberPageコンポーネントを拡張する方式から，TrainNumberPageをページ側から呼び出す方式に実装を変更