### PR TITLE
Nodeのバージョンを14.17.4に更新

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.18.1]
+        node-version: [14.17.4]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.4-slim
+FROM node:14.17.4-slim
 
 WORKDIR /app
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   command = "yarn run generate"
 
 [build.environment]
-  NODE_VERSION = "12.18.1"
+  NODE_VERSION = "14.17.4"


### PR DESCRIPTION
# 概要

Node 12では動かないので，Nodeのバージョンを14.17.4に更新