### PR TITLE
ラジオボタンのname属性を修正

### DIFF
--- a/components/pages/qr-code/ErrorCorrectionLevelField.vue
+++ b/components/pages/qr-code/ErrorCorrectionLevelField.vue
@@ -13,7 +13,7 @@
         <b-radio
           :native-value="levelForm.value"
           v-model="level"
-          name="name"
+          name="error-correction-level"
         >
           {{ levelForm.text }}
         </b-radio>

--- a/components/pages/qr-code/RenderAsField.vue
+++ b/components/pages/qr-code/RenderAsField.vue
@@ -13,7 +13,7 @@
         <b-radio
           :native-value="renderAsForm.value"
           v-model="renderAs"
-          name="name"
+          name="render-as"
         >
           {{ renderAsForm.text }}
         </b-radio>


### PR DESCRIPTION
# 概要

ラジオボタンのname属性を修正．
nama属性が被っていたので変えた．