### PR TITLE
Node.jsのバージョンを18.14.2に更新

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.17.4]
+        node-version: [18.14.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:14.20.0-slim
+FROM node:18.14.2-slim
 
 WORKDIR /app
 
 ENV HOST "0.0.0.0"
 
-RUN apt update -y && \
-    apt install -y --no-install-recommends tzdata g++ make python && \
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends tzdata g++ make python && \
     apt-get clean && \
     rm -rf /var/lib/opt/lists/*
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   command = "yarn run generate"
 
 [build.environment]
-  NODE_VERSION = "14.17.4"
+  NODE_VERSION = "18.14.2"


### PR DESCRIPTION
# 概要

Node.jsのバージョンを18.14.2に更新