### PR TITLE
乗車券の経路作成ページを作成

### DIFF
--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -73,6 +73,9 @@
           <b-button @click="addRoute(-1)" type="is-info">
             追加
           </b-button>
+          <b-button @click="reverseRoutes" type="is-info is-light">
+            逆向き
+          </b-button>
           <b-button @click="removeEmptyRoutes" type="is-danger is-light">
             空の経路を削除
           </b-button>
@@ -167,6 +170,16 @@ export default defineComponent({
     const valuedRoutes = computed<Route[]>(() => {
       return routes.value.filter((route) => route.line.trim() !== '');
     });
+    const reverseRoutes = () => {
+      const newDeparture = destination.value;
+      destination.value = departure.value;
+      departure.value = newDeparture;
+      removeEmptyRoutes();
+      routes.value = routes.value.reverse().map((route, index, orig) => {
+        route.station = orig[index + 1] == null ? '' : orig[index + 1].station;
+        return route;
+      });
+    };
     const addRoute = (index: number) => {
       if (index <= -1) {
         routes.value.push(createRoute());
@@ -216,6 +229,7 @@ export default defineComponent({
       removeAllSettings,
       createRoute,
       routes,
+      reverseRoutes,
       addRoute,
       deleteRoute,
       removeEmptyRoutes,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -146,6 +146,9 @@
           <b-button @click="setUndefinedDate" type="is-info is-light">
             利用日未定
           </b-button>
+          <b-button @click="setSkipDate" type="is-info is-light">
+            {{ skipDate ? '利用日非省略' : '利用日省略' }}
+          </b-button>
           <b-button @click="addRoute(-1)" type="is-info">
             経路追加
           </b-button>
@@ -198,15 +201,18 @@ export default defineComponent({
     const types = [
       '片道乗車券',
       '往復乗車券',
-      '連続乗車券',
+      '連続乗車券 (連続1)',
+      '連続乗車券 (連続2)',
     ];
     const type = ref<string>('片道乗車券');
     const month = ref<string>('');
     const day = ref<string>('');
+    const skipDate = ref<boolean>(false);
     const departure = ref<string>('');
     const destination = ref<string>('');
     const removeAllSettings = () => {
       type.value = types[0];
+      skipDate.value = false;
       [month, day, departure, destination].forEach(ref => {
         ref.value = '';
       });
@@ -229,6 +235,16 @@ export default defineComponent({
       const undefinedDate = '     ';
       month.value = undefinedDate;
       day.value = undefinedDate;
+    };
+    const setSkipDate = () => {
+      skipDate.value = !skipDate.value;
+      if (skipDate.value) {
+        month.value = '省略';
+        day.value = '省略';
+      } else {
+        month.value = '';
+        day.value = '';
+      }
     };
     const reverseRoutes = () => {
       const newDeparture = destination.value;
@@ -267,7 +283,11 @@ export default defineComponent({
       return output.trim();
     };
     const output = computed<string>(() => {
-      const header = `${type.value}\n\n利用開始日: ${month.value}月${day.value}日\n\n区間: ${departure.value}→${destination.value}`;
+      const header = [
+        type.value,
+        skipDate.value ? null : `利用開始日: ${month.value}月${day.value}日`,
+        `区間: ${departure.value}→${destination.value}`,
+      ].filter((el) => el != null).join('\n\n');
       const routesOutput = valuedRoutes.value.length === 0 ? '' : createRoutesOutput();
       const content = `経由: ${routesOutput}`;
       const footer = notes.value.trim() === '' ? '' : `備考: ${notes.value.trim()}`;
@@ -302,6 +322,7 @@ export default defineComponent({
       type,
       month,
       day,
+      skipDate,
       departure,
       destination,
       removeAllSettings,
@@ -310,6 +331,7 @@ export default defineComponent({
       notes,
       setDate,
       setUndefinedDate,
+      setSkipDate,
       reverseRoutes,
       addRoute,
       deleteRoute,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -191,7 +191,8 @@ export default defineComponent({
     const departure = ref<string>('');
     const destination = ref<string>('');
     const removeAllSettings = () => {
-      [type, month, day, departure, destination].forEach(ref => {
+      type.value = types[0];
+      [month, day, departure, destination].forEach(ref => {
         ref.value = '';
       });
     };

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -143,6 +143,12 @@
           備考
         </h3>
 
+        <div class="buttons">
+          <b-button @click="notes = ''" type="is-danger">
+            クリア
+          </b-button>
+        </div>
+
         <b-field label="備考">
           <b-input
             v-model="notes"

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -70,7 +70,7 @@
           経路
         </h3>
         <div class="buttons">
-          <b-button @click="addRoute" type="is-info">
+          <b-button @click="addRoute(-1)" type="is-info">
             追加
           </b-button>
           <b-button @click="removeEmptyRoutes" type="is-danger is-light">
@@ -98,6 +98,7 @@
                 type="text"
                 placeholder="路線名"
                 @keydown.tab.native="onKeyupTab(routeIndex)"
+                @keydown.shift.enter.native="addRoute(routeIndex)"
               ></b-input>
             </b-field>
           </div>
@@ -107,6 +108,7 @@
                 v-model="route.station"
                 type="text"
                 placeholder="接続駅"
+                @keydown.shift.enter.native="addRoute(routeIndex)"
               ></b-input>
             </b-field>
           </div>
@@ -165,7 +167,13 @@ export default defineComponent({
     const valuedRoutes = computed<Route[]>(() => {
       return routes.value.filter((route) => route.line.trim() !== '');
     });
-    const addRoute = () => routes.value.push(createRoute());
+    const addRoute = (index: number) => {
+      if (index <= -1) {
+        routes.value.push(createRoute());
+      } else {
+        routes.value.splice(index + 1, 0, createRoute());
+      }
+    };
     const deleteRoute = (index: number) => routes.value.splice(index, 1);
     const removeEmptyRoutes = () => {
       const newRoutes = routes.value.filter(route => {
@@ -176,7 +184,7 @@ export default defineComponent({
     const removeAllRoutes = () => (routes.value = [createRoute()]);
     const onKeyupTab = (index: number) => {
       if (routes.value.length - 1 === index) {
-        addRoute();
+        addRoute(-1);
       }
     };
     const createRoutesOutput = () => {

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -35,6 +35,7 @@
                 v-model="month"
                 type="text"
                 placeholder="月"
+                :disabled="skipDate"
               ></b-input>
               <p class="control">
                 <span class="button is-static">月</span>
@@ -44,6 +45,7 @@
                 v-model="day"
                 type="text"
                 placeholder="日"
+                :disabled="skipDate"
               ></b-input>
               <p class="control">
                 <span class="button is-static">日</span>
@@ -226,15 +228,31 @@ export default defineComponent({
       return routes.value.filter((route) => route.line.trim() !== '');
     });
     const setDate = (addDate: number) => {
-      const today = new Date();
-      today.setDate(today.getDate() + addDate);
-      month.value = (today.getMonth() + 1).toString();
-      day.value = today.getDate().toString();
+      if (skipDate.value) {
+        Snackbar.open({
+          message: '利用日省略が設定されています。',
+          pauseOnHover: true,
+          type: 'is-info',
+        });
+      } else {
+        const today = new Date();
+        today.setDate(today.getDate() + addDate);
+        month.value = (today.getMonth() + 1).toString();
+        day.value = today.getDate().toString();
+      }
     };
     const setUndefinedDate = () => {
-      const undefinedDate = '     ';
-      month.value = undefinedDate;
-      day.value = undefinedDate;
+      if (skipDate.value) {
+        Snackbar.open({
+          message: '利用日省略が設定されています。',
+          pauseOnHover: true,
+          type: 'is-info',
+        });
+      } else {
+        const undefinedDate = '     ';
+        month.value = undefinedDate;
+        day.value = undefinedDate;
+      }
     };
     const setSkipDate = () => {
       skipDate.value = !skipDate.value;

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -134,6 +134,15 @@
         </h3>
 
         <div class="buttons">
+          <b-button @click="setDate(0)" type="is-info is-light">
+            本日
+          </b-button>
+          <b-button @click="setDate(1)" type="is-info is-light">
+            明日
+          </b-button>
+          <b-button @click="setDate(2)" type="is-info is-light">
+            明後日
+          </b-button>
           <b-button @click="setUndefinedDate" type="is-info is-light">
             利用日未定
           </b-button>
@@ -210,6 +219,12 @@ export default defineComponent({
     const valuedRoutes = computed<Route[]>(() => {
       return routes.value.filter((route) => route.line.trim() !== '');
     });
+    const setDate = (addDate: number) => {
+      const today = new Date();
+      today.setDate(today.getDate() + addDate);
+      month.value = (today.getMonth() + 1).toString();
+      day.value = today.getDate().toString();
+    };
     const setUndefinedDate = () => {
       const undefinedDate = '     ';
       month.value = undefinedDate;
@@ -293,6 +308,7 @@ export default defineComponent({
       createRoute,
       routes,
       notes,
+      setDate,
       setUndefinedDate,
       reverseRoutes,
       addRoute,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -12,13 +12,16 @@
           設定
         </h3>
         <div class="buttons">
+          <b-button @click="setUndefinedDate" type="is-info is-light">
+            利用日未定
+          </b-button>
           <b-button @click="removeAllSettings" type="is-danger">
             全ての設定を削除
           </b-button>
         </div>
 
         <div class="columns">
-          <div class="column">
+          <div class="column is-2">
             <b-field label="券種">
               <b-select
                 v-model="type"
@@ -35,13 +38,28 @@
               </b-select>
             </b-field>
           </div>
-          <div class="column">
+          <div class="column is-1">
+            <b-field label="利用開始月">
+              <b-input
+                v-model="month"
+                type="text"
+                placeholder="月"
+              ></b-input>
+              <p class="control">
+                <span class="button is-static">月</span>
+              </p>
+            </b-field>
+          </div>
+          <div class="column is-1">
             <b-field label="利用開始日">
               <b-input
-                v-model="date"
+                v-model="day"
                 type="text"
-                placeholder="利用開始日"
+                placeholder="日"
               ></b-input>
+              <p class="control">
+                <span class="button is-static">日</span>
+              </p>
             </b-field>
           </div>
           <div class="column">
@@ -169,11 +187,12 @@ export default defineComponent({
       '連続乗車券',
     ];
     const type = ref<string>('片道乗車券');
-    const date = ref<string>('');
+    const month = ref<string>('');
+    const day = ref<string>('');
     const departure = ref<string>('');
     const destination = ref<string>('');
     const removeAllSettings = () => {
-      [type, date, departure, destination].forEach(ref => {
+      [type, month, day, departure, destination].forEach(ref => {
         ref.value = '';
       });
     };
@@ -185,6 +204,11 @@ export default defineComponent({
     const valuedRoutes = computed<Route[]>(() => {
       return routes.value.filter((route) => route.line.trim() !== '');
     });
+    const setUndefinedDate = () => {
+      const undefinedDate = '     ';
+      month.value = undefinedDate;
+      day.value = undefinedDate;
+    };
     const reverseRoutes = () => {
       const newDeparture = destination.value;
       destination.value = departure.value;
@@ -222,7 +246,7 @@ export default defineComponent({
       return output.trim();
     };
     const output = computed<string>(() => {
-      const header = `${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}`;
+      const header = `${type.value}\n\n利用開始日: ${month.value}月${day.value}日\n\n区間: ${departure.value}→${destination.value}`;
       const routesOutput = valuedRoutes.value.length === 0 ? '' : createRoutesOutput();
       const content = `経由: ${routesOutput}`;
       const footer = notes.value.trim() === '' ? '' : `備考: ${notes.value.trim()}`;
@@ -241,13 +265,15 @@ export default defineComponent({
       description,
       types,
       type,
-      date,
+      month,
+      day,
       departure,
       destination,
       removeAllSettings,
       createRoute,
       routes,
       notes,
+      setUndefinedDate,
       reverseRoutes,
       addRoute,
       deleteRoute,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -20,11 +20,19 @@
         <div class="columns">
           <div class="column">
             <b-field label="券種">
-              <b-input
+              <b-select
                 v-model="type"
-                type="text"
-                placeholder="券種"
-              ></b-input>
+                placeholder="乗車券の種類を選択"
+                expanded
+              >
+                <option
+                  v-for="(option, typesIndex) in types"
+                  :value="option"
+                  :key="typesIndex"
+                >
+                  {{ option }}
+                </option>
+              </b-select>
             </b-field>
           </div>
           <div class="column">
@@ -135,7 +143,13 @@ export default defineComponent({
   setup () {
     const title = ref<string>('乗車券の経路作成');
     const description = ref<string>('複雑な経路の乗車券を窓口で作る際に紙に書く経路を作るツール');
-    const type = ref<string>('');
+
+    const types = [
+      '片道乗車券',
+      '往復乗車券',
+      '連続乗車券',
+    ];
+    const type = ref<string>('片道乗車券');
     const date = ref<string>('');
     const departure = ref<string>('');
     const destination = ref<string>('');
@@ -186,6 +200,7 @@ export default defineComponent({
     return {
       title,
       description,
+      types,
       type,
       date,
       departure,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -65,7 +65,7 @@
         </div>
       </div>
 
-      <div class="content routes block">
+      <div class="content routes">
         <h3>
           経路
         </h3>
@@ -125,7 +125,21 @@
         </div>
       </div>
 
-      <div class="content routes">
+      <div class="content notes">
+        <h3>
+          備考
+        </h3>
+
+        <b-field label="備考">
+          <b-input
+            v-model="notes"
+            type="textarea"
+            placeholder="備考"
+          ></b-input>
+        </b-field>
+      </div>
+
+      <div class="content output">
         <h3>
           出力
         </h3>
@@ -167,6 +181,7 @@ export default defineComponent({
       return { line: '', station: '' };
     };
     const routes = ref<Route[]>([createRoute()]);
+    const notes = ref<string>('');
     const valuedRoutes = computed<Route[]>(() => {
       return routes.value.filter((route) => route.line.trim() !== '');
     });
@@ -207,8 +222,11 @@ export default defineComponent({
       return output.trim();
     };
     const output = computed<string>(() => {
+      const header = `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}`;
       const routesOutput = valuedRoutes.value.length === 0 ? '' : createRoutesOutput();
-      return `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}\n\n経由: ${routesOutput}`;
+      const content = `経由: ${routesOutput}`;
+      const footer = notes.value.trim() === '' ? '' : `備考: ${notes.value.trim()}`;
+      return `${header}\n\n${content}\n\n${footer}`.trim();
     });
 
     useMeta(() => ({
@@ -229,6 +247,7 @@ export default defineComponent({
       removeAllSettings,
       createRoute,
       routes,
+      notes,
       reverseRoutes,
       addRoute,
       deleteRoute,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -159,6 +159,9 @@
         <h3>
           出力
         </h3>
+        <b-button @click="copyOutput" size="is-small">
+          Copy
+        </b-button>
         <pre v-text="output"></pre>
       </div>
     </div>
@@ -167,6 +170,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, ref, useMeta } from '@nuxtjs/composition-api';
+import { SnackbarProgrammatic as Snackbar } from 'buefy';
 
 interface Route {
   line: string;
@@ -250,6 +254,20 @@ export default defineComponent({
       const footer = notes.value.trim() === '' ? '' : `備考: ${notes.value.trim()}`;
       return `${header}\n\n${content}\n\n${footer}`.trim();
     });
+    const copyOutput = () => {
+      navigator.clipboard.writeText(output.value)
+        .then((t) => {
+          Snackbar.open({
+            message: 'Copied!',
+            pauseOnHover: true,
+            type: 'is-link',
+          });
+          return t;
+        })
+        .catch(e => {
+          console.error(e);
+        });
+    };
 
     useMeta(() => ({
       title: title.value,
@@ -279,6 +297,7 @@ export default defineComponent({
       removeAllRoutes,
       onKeyupTab,
       output,
+      copyOutput,
     };
   },
   components: {

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -38,8 +38,8 @@
               </b-select>
             </b-field>
           </div>
-          <div class="column is-1">
-            <b-field label="利用開始月">
+          <div class="column is-2">
+            <b-field label="利用開始日">
               <b-input
                 v-model="month"
                 type="text"
@@ -48,10 +48,7 @@
               <p class="control">
                 <span class="button is-static">月</span>
               </p>
-            </b-field>
-          </div>
-          <div class="column is-1">
-            <b-field label="利用開始日">
+
               <b-input
                 v-model="day"
                 type="text"

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -11,6 +11,12 @@
         <h3>
           設定
         </h3>
+        <div class="buttons">
+          <b-button @click="removeAllSettings" type="is-danger">
+            全ての設定を削除
+          </b-button>
+        </div>
+
         <div class="columns">
           <div class="column">
             <b-field label="券種">
@@ -133,6 +139,11 @@ export default defineComponent({
     const date = ref<string>('');
     const departure = ref<string>('');
     const destination = ref<string>('');
+    const removeAllSettings = () => {
+      [type, date, departure, destination].forEach(ref => {
+        ref.value = '';
+      });
+    };
     const createRoute = (): Route => {
       return { line: '', station: '' };
     };
@@ -179,6 +190,7 @@ export default defineComponent({
       date,
       departure,
       destination,
+      removeAllSettings,
       createRoute,
       routes,
       addRoute,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -97,7 +97,11 @@
             </b-field>
           </div>
           <div class="column is-1">
-            <button class="delete" tabindex="-1"></button>
+            <button
+              @click="deleteRoute(routeIndex)"
+              class="delete"
+              tabindex="-1"
+            ></button>
           </div>
         </div>
       </div>
@@ -137,6 +141,7 @@ export default defineComponent({
       return routes.value.filter((route) => route.line.trim() !== '');
     });
     const addRoute = () => routes.value.push(createRoute());
+    const deleteRoute = (index: number) => routes.value.splice(index, 1);
     const removeEmptyRoutes = () => {
       const newRoutes = routes.value.filter(route => {
         return route.line.trim() !== '' || route.station.trim() !== '';
@@ -177,6 +182,7 @@ export default defineComponent({
       createRoute,
       routes,
       addRoute,
+      deleteRoute,
       removeEmptyRoutes,
       removeAllRoutes,
       onKeyupTab,

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -111,6 +111,11 @@
             <p>
               路線数: {{ routeIndex + 1 }}
             </p>
+            <button
+              @click="deleteRoute(routeIndex)"
+              class="delete"
+              tabindex="-1"
+            ></button>
           </div>
           <div class="column">
             <b-field label="路線名">
@@ -132,13 +137,6 @@
                 @keydown.shift.enter.native="addRoute(routeIndex)"
               ></b-input>
             </b-field>
-          </div>
-          <div class="column is-1">
-            <button
-              @click="deleteRoute(routeIndex)"
-              class="delete"
-              tabindex="-1"
-            ></button>
           </div>
         </div>
       </div>

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -11,15 +11,6 @@
         <h3>
           設定
         </h3>
-        <div class="buttons">
-          <b-button @click="setUndefinedDate" type="is-info is-light">
-            利用日未定
-          </b-button>
-          <b-button @click="removeAllSettings" type="is-danger">
-            全ての設定を削除
-          </b-button>
-        </div>
-
         <div class="columns">
           <div class="column is-2">
             <b-field label="券種">
@@ -84,20 +75,6 @@
         <h3>
           経路
         </h3>
-        <div class="buttons">
-          <b-button @click="addRoute(-1)" type="is-info">
-            追加
-          </b-button>
-          <b-button @click="reverseRoutes" type="is-info is-light">
-            逆向き
-          </b-button>
-          <b-button @click="removeEmptyRoutes" type="is-danger is-light">
-            空の経路を削除
-          </b-button>
-          <b-button @click="removeAllRoutes" type="is-danger">
-            全ての経路を削除
-          </b-button>
-        </div>
 
         <div
           v-for="(route, routeIndex) in routes"
@@ -142,13 +119,6 @@
         <h3>
           備考
         </h3>
-
-        <div class="buttons">
-          <b-button @click="notes = ''" type="is-danger">
-            クリア
-          </b-button>
-        </div>
-
         <b-field label="備考">
           <b-input
             v-model="notes"
@@ -156,6 +126,36 @@
             placeholder="備考"
           ></b-input>
         </b-field>
+      </div>
+
+      <div class="content notes">
+        <h3>
+          入力操作
+        </h3>
+
+        <div class="buttons">
+          <b-button @click="setUndefinedDate" type="is-info is-light">
+            利用日未定
+          </b-button>
+          <b-button @click="addRoute(-1)" type="is-info">
+            経路追加
+          </b-button>
+          <b-button @click="reverseRoutes" type="is-info is-light">
+            逆向き
+          </b-button>
+          <b-button @click="removeEmptyRoutes" type="is-danger is-light">
+            空経路削除
+          </b-button>
+          <b-button @click="removeAllSettings" type="is-danger">
+            全設定クリア
+          </b-button>
+          <b-button @click="removeAllRoutes" type="is-danger">
+            全経路クリア
+          </b-button>
+          <b-button @click="notes = ''" type="is-danger">
+            備考クリア
+          </b-button>
+        </div>
       </div>
 
       <div class="content output">

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -118,9 +118,6 @@
       </div>
 
       <div class="content notes">
-        <h3>
-          備考
-        </h3>
         <b-field label="備考">
           <b-input
             v-model="notes"
@@ -130,9 +127,9 @@
         </b-field>
       </div>
 
-      <div class="content notes">
+      <div class="content actions">
         <h3>
-          入力操作
+          操作
         </h3>
 
         <div class="buttons">

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -222,7 +222,7 @@ export default defineComponent({
       return output.trim();
     };
     const output = computed<string>(() => {
-      const header = `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}`;
+      const header = `${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}`;
       const routesOutput = valuedRoutes.value.length === 0 ? '' : createRoutesOutput();
       const content = `経由: ${routesOutput}`;
       const footer = notes.value.trim() === '' ? '' : `備考: ${notes.value.trim()}`;

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -1,0 +1,109 @@
+<template>
+  <section class="section">
+    <div class="container">
+      <h1 class="title" v-text="title">
+      </h1>
+
+      <h2 class="subtitle" v-text="description">
+      </h2>
+
+      <div class="content settings">
+        <h3>
+          設定
+        </h3>
+        <div class="columns">
+          <div class="column">
+            <b-field label="券種">
+              <b-input
+                v-model="type"
+                type="text"
+                placeholder="券種"
+              ></b-input>
+            </b-field>
+          </div>
+          <div class="column">
+            <b-field label="利用開始日">
+              <b-input
+                v-model="date"
+                type="text"
+                placeholder="利用開始日"
+              ></b-input>
+            </b-field>
+          </div>
+          <div class="column">
+            <b-field label="発駅">
+              <b-input
+                v-model="departure"
+                type="text"
+                placeholder="発駅"
+              ></b-input>
+            </b-field>
+          </div>
+          <div class="column">
+            <b-field label="着駅">
+              <b-input
+                v-model="destination"
+                type="text"
+                placeholder="着駅"
+              ></b-input>
+            </b-field>
+          </div>
+        </div>
+      </div>
+
+      <div class="content routes">
+        <h3>
+          経路
+        </h3>
+      </div>
+
+      <div class="content routes">
+        <h3>
+          出力
+        </h3>
+        <pre v-text="output"></pre>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref, useMeta } from '@nuxtjs/composition-api';
+
+export default defineComponent({
+  head: {},
+  setup () {
+    const title = ref<string>('乗車券の経路作成');
+    const description = ref<string>('複雑な経路の乗車券を窓口で作る際に紙に書く経路を作るツール');
+    const type = ref<string>('');
+    const date = ref<string>('');
+    const departure = ref<string>('');
+    const destination = ref<string>('');
+    const output = computed<string>(() => {
+      return `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}\n\n`;
+    });
+
+    useMeta(() => ({
+      title: title.value,
+      meta: [
+        { hid: 'description', name: 'description', content: description.value },
+      ],
+    }));
+
+    return {
+      title,
+      description,
+      type,
+      date,
+      departure,
+      destination,
+      output,
+    };
+  },
+  components: {
+  },
+});
+</script>
+
+<style scoped lang="scss">
+</style>

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -133,6 +133,9 @@ export default defineComponent({
       return { line: '', station: '' };
     };
     const routes = ref<Route[]>([createRoute()]);
+    const valuedRoutes = computed<Route[]>(() => {
+      return routes.value.filter((route) => route.line.trim() !== '');
+    });
     const addRoute = () => routes.value.push(createRoute());
     const removeEmptyRoutes = () => {
       const newRoutes = routes.value.filter(route => {
@@ -146,8 +149,14 @@ export default defineComponent({
         addRoute();
       }
     };
+    const createRoutesOutput = () => {
+      const exceptLastRoutes = valuedRoutes.value.slice(0, valuedRoutes.value.length - 1);
+      const lastRoute = valuedRoutes.value.slice(-1)[0];
+      const output = exceptLastRoutes.map(route => `${route.line} (${route.station})`).join(' ') + ` ${lastRoute.line}`;
+      return output.trim();
+    };
     const output = computed<string>(() => {
-      const routesOutput = routes.value.map(route => `${route.line} (${route.station})`).join(' ');
+      const routesOutput = valuedRoutes.value.length === 0 ? '' : createRoutesOutput();
       return `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}\n\n経由: ${routesOutput}`;
     });
 

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -51,10 +51,55 @@
         </div>
       </div>
 
-      <div class="content routes">
+      <div class="content routes block">
         <h3>
           経路
         </h3>
+        <div class="buttons">
+          <b-button @click="addRoute" type="is-info">
+            追加
+          </b-button>
+          <b-button @click="removeEmptyRoutes" type="is-danger is-light">
+            空の経路を削除
+          </b-button>
+          <b-button @click="removeAllRoutes" type="is-danger">
+            全ての経路を削除
+          </b-button>
+        </div>
+
+        <div
+          v-for="(route, routeIndex) in routes"
+          :key="routeIndex"
+          class="columns"
+        >
+          <div class="column is-1">
+            <p>
+              路線数: {{ routeIndex + 1 }}
+            </p>
+          </div>
+          <div class="column">
+            <b-field label="路線名">
+              <b-input
+                v-model="route.line"
+                type="text"
+                placeholder="路線名"
+                @keydown.tab.native="onKeyupTab(routeIndex)"
+              ></b-input>
+            </b-field>
+          </div>
+          <div class="column">
+            <b-field label="接続駅">
+              <b-input
+                v-model="route.station"
+                type="text"
+                placeholder="接続駅"
+              ></b-input>
+            </b-field>
+          </div>
+          <div class="column is-1">
+            <button class="delete" tabindex="-1"></button>
+          </div>
+        </div>
       </div>
 
       <div class="content routes">
@@ -70,6 +115,11 @@
 <script lang="ts">
 import { computed, defineComponent, ref, useMeta } from '@nuxtjs/composition-api';
 
+interface Route {
+  line: string;
+  station: string;
+}
+
 export default defineComponent({
   head: {},
   setup () {
@@ -79,6 +129,23 @@ export default defineComponent({
     const date = ref<string>('');
     const departure = ref<string>('');
     const destination = ref<string>('');
+    const createRoute = (): Route => {
+      return { line: '', station: '' };
+    };
+    const routes = ref<Route[]>([createRoute()]);
+    const addRoute = () => routes.value.push(createRoute());
+    const removeEmptyRoutes = () => {
+      const newRoutes = routes.value.filter(route => {
+        return route.line.trim() !== '' || route.station.trim() !== '';
+      });
+      routes.value = newRoutes.length === 0 ? [createRoute()] : newRoutes;
+    };
+    const removeAllRoutes = () => (routes.value = [createRoute()]);
+    const onKeyupTab = (index: number) => {
+      if (routes.value.length - 1 === index) {
+        addRoute();
+      }
+    };
     const output = computed<string>(() => {
       return `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}\n\n`;
     });
@@ -97,6 +164,12 @@ export default defineComponent({
       date,
       departure,
       destination,
+      createRoute,
+      routes,
+      addRoute,
+      removeEmptyRoutes,
+      removeAllRoutes,
+      onKeyupTab,
       output,
     };
   },

--- a/pages/fare-ticket-route/index.vue
+++ b/pages/fare-ticket-route/index.vue
@@ -147,7 +147,8 @@ export default defineComponent({
       }
     };
     const output = computed<string>(() => {
-      return `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}\n\n`;
+      const routesOutput = routes.value.map(route => `${route.line} (${route.station})`).join(' ');
+      return `券種: ${type.value}\n\n利用開始日: ${date.value}\n\n区間: ${departure.value}→${destination.value}\n\n経由: ${routesOutput}`;
     });
 
     useMeta(() => ({

--- a/store/pageLinks.ts
+++ b/store/pageLinks.ts
@@ -38,6 +38,10 @@ export const state = (): PageLinksState => ({
     title: 'EMVコンタクトレスのサウンドをWeb Audio APIで再生',
     to: '/cl-sound',
   },
+  fareTicketRoute: {
+    title: '乗車券の経路作成',
+    to: '/fare-ticket-route',
+  },
 });
 
 export const getters: GetterTree<PageLinksState, RootState> = {
@@ -48,6 +52,7 @@ export const getters: GetterTree<PageLinksState, RootState> = {
       state.trainNumberCalcPageLink,
       state.qrCodeGeneratorPageLink,
       state.contactlessSoundPage,
+      state.fareTicketRoute,
     ];
   },
   pageLinks (state: PageLinksState): Link[] {
@@ -56,6 +61,7 @@ export const getters: GetterTree<PageLinksState, RootState> = {
       state.trainNumberCalcPageLink,
       state.qrCodeGeneratorPageLink,
       state.contactlessSoundPage,
+      state.fareTicketRoute,
     ];
   },
   trainNumberContentPageLinks (state: PageLinksState): Link[] {

--- a/types/state.d.ts
+++ b/types/state.d.ts
@@ -10,6 +10,7 @@ export interface PageLinksState {
   trainNumberCalcPageLink: Link;
   qrCodeGeneratorPageLink: Link;
   contactlessSoundPage: Link;
+  fareTicketRoute: Link;
 }
 
 export interface QrCodeGeneratorState {


### PR DESCRIPTION
# 概要

乗車券の経路作成ページを作成。
みどりの窓口で複雑な経路の乗車券を出す際，手入力でGoogleドキュメントに書いた上で印刷しているが手入力で経路の括弧などを打つのは面倒なので補助ツールで入力出来るようにする。