### PR TITLE
QRコードのマージンを設定できるようにした

### DIFF
--- a/components/pages/qr-code/MarginField.vue
+++ b/components/pages/qr-code/MarginField.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="my-5">
+    <label for="margin" class="block text-lg font-semibold text-slate-700">
+      マージン
+    </label>
+    <span class="block text-slate-700">
+      {{ margin }}
+    </span>
+    <input
+      v-model="margin"
+      :min="0"
+      :max="500"
+      id="margin"
+      type="range"
+      class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+    >
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useQrCodeGeneratorStore } from '~/store/qrCodeGenerator';
+
+const store = useQrCodeGeneratorStore();
+const margin = computed<number>({
+  get: () => {
+    return store.margin;
+  },
+  set: (val) => {
+    store.margin = Number(val);
+  },
+});
+</script>

--- a/pages/qr-code/index.vue
+++ b/pages/qr-code/index.vue
@@ -33,6 +33,7 @@
       <qr-code-vue
         :value="value"
         :size="size"
+        :margin="margin"
         :level="level"
         :render-as="renderAs"
         :background="backGround"
@@ -71,6 +72,7 @@ export default defineComponent({
 
     const value = computed(() => store.value);
     const size = computed(() => store.size);
+    const margin = computed(() => store.margin);
     const level = computed(() => store.level);
     const renderAs = computed(() => store.renderAs);
     const backGround = computed(() => store.backGround);
@@ -81,6 +83,7 @@ export default defineComponent({
       description,
       value,
       size,
+      margin,
       level,
       renderAs,
       backGround,

--- a/pages/qr-code/index.vue
+++ b/pages/qr-code/index.vue
@@ -14,6 +14,9 @@
         <size-field>
         </size-field>
 
+        <margin-field>
+        </margin-field>
+
         <error-correction-level-field>
         </error-correction-level-field>
 
@@ -45,6 +48,7 @@
 import QrCodeVue from 'qrcode.vue';
 import ValueField from '~/components/pages/qr-code/ValueField';
 import SizeField from '~/components/pages/qr-code/SizeField';
+import MarginField from '~/components/pages/qr-code/MarginField';
 import ErrorCorrectionLevelField from '~/components/pages/qr-code/ErrorCorrectionLevelField';
 import RenderAsField from '~/components/pages/qr-code/RenderAsField';
 import BackGroundField from '~/components/pages/qr-code/BackGroundField';
@@ -87,6 +91,7 @@ export default defineComponent({
     QrCodeVue,
     ValueField,
     SizeField,
+    MarginField,
     ErrorCorrectionLevelField,
     RenderAsField,
     BackGroundField,

--- a/store/qrCodeGenerator.ts
+++ b/store/qrCodeGenerator.ts
@@ -1,10 +1,11 @@
 import { defineStore } from 'pinia';
-import { QrCodeGeneratorState } from '../types';
+import { QrCodeGeneratorState } from '~/types';
 
 export const useQrCodeGeneratorStore = defineStore<'QrCodeGenerator', QrCodeGeneratorState>('QrCodeGenerator', {
   state: () => ({
     value: '',
     size: 250,
+    margin: 0,
     level: 'H',
     renderAs: 'canvas',
     backGround: '#ffffff',

--- a/types/state.d.ts
+++ b/types/state.d.ts
@@ -40,6 +40,7 @@ export interface FareTicketRouteStoreActions {
 export interface QrCodeGeneratorState {
   value: string;
   size: number;
+  margin: number;
   level: QrCodeErrorCorrectionLevel;
   renderAs: QrCodeRenderAsOptionValue;
   backGround: string;


### PR DESCRIPTION
# 概要

ライブラリ更新でmarginオプションが使えるようになったので，QRコードのマージンを設定できるようにした。